### PR TITLE
GM-162 ChatRoom에 Soft Delete 적용

### DIFF
--- a/src/main/java/com/gaaji/chat/domain/chatroom/ChatRoom.java
+++ b/src/main/java/com/gaaji/chat/domain/chatroom/ChatRoom.java
@@ -3,6 +3,8 @@ package com.gaaji.chat.domain.chatroom;
 import com.gaaji.chat.domain.User;
 import com.gaaji.chat.domain.post.Post;
 import lombok.Getter;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -15,6 +17,8 @@ import java.util.UUID;
 @Entity
 @Getter
 @EntityListeners(AuditingEntityListener.class)
+@SQLDelete(sql = "update chat_room set deleted_at = current_timestamp where id = ?")
+@Where(clause = "deleted_at is null")
 public class ChatRoom {
     @Id
     private String id;
@@ -28,6 +32,8 @@ public class ChatRoom {
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Post post;
+
+    private LocalDateTime deletedAt;
 
     public static ChatRoom createChatRoom() {
         ChatRoom chatRoom = new ChatRoom();

--- a/src/main/java/com/gaaji/chat/service/GroupChatServiceImpl.java
+++ b/src/main/java/com/gaaji/chat/service/GroupChatServiceImpl.java
@@ -31,9 +31,10 @@ public class GroupChatServiceImpl implements GroupChatService {
     private final PostRepository postRepository;
     private final KafkaTemplate<String, String> kafkaTemplate;
 
+
     @Override
     @Transactional
-    @KafkaListener(topics = "post-banzzakCreated", errorHandler = "kafkaErrorHandler")
+    @KafkaListener(topics = "post-banzzakCreated", errorHandler = "kafkaErrorHandler", clientIdPrefix = "post-banzzakCreated")
     public void handleBanzzakCreated(String body) throws JsonProcessingException {
         log.info("Event Caught: post-banzzakCreated " + body);
         ObjectMapper objectMapper = new ObjectMapper();
@@ -53,7 +54,7 @@ public class GroupChatServiceImpl implements GroupChatService {
 
     @Override
     @Transactional
-    @KafkaListener(topics = "post-banzzakUserJoined", errorHandler = "kafkaErrorHandler")
+    @KafkaListener(topics = "post-banzzakUserJoined", errorHandler = "kafkaErrorHandler", clientIdPrefix = "post-banzzakUserJoined")
     public void handleBanzzakUserJoined(String body) throws JsonProcessingException {
         log.info("Event Caught: post-banzzakUserJoined " + body);
         ObjectMapper objectMapper = new ObjectMapper();
@@ -75,7 +76,7 @@ public class GroupChatServiceImpl implements GroupChatService {
     }
 
     @Override
-    @KafkaListener(topics = "post-banzzakUserLeft", errorHandler = "kafkaErrorHandler")
+    @KafkaListener(topics = "post-banzzakUserLeft", errorHandler = "kafkaErrorHandler", clientIdPrefix = "post-banzzakUserLeft")
     @Transactional
     public void handleBanzzakUserLeft(String body) throws JsonProcessingException {
         log.info("Event Caught: post-banzzakUserLeft " + body);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
   kafka:
     bootstrap-servers: localhost:9092
     consumer:
-      group-id: kafka-test
+      group-id: chat-api
       auto-offset-reset: earliest
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer


### PR DESCRIPTION
# GM-162 ChatRoom에 Soft Delete 적용

## PR Type
- [ ] Hotfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor (code, package, etc.)
- [ ] Build (gradle, spring, etc) 
- [ ] Documentation content changes (api docs, etc.)
- [ ] Infra (cloud, security, etc.)
- [ ] Other... Please describe :

## Issues
```java
@Entity
@Getter
@EntityListeners(AuditingEntityListener.class)
@SQLDelete(sql = "update chat_room set deleted_at = current_timestamp where id = ?")
@Where(clause = "deleted_at is null")
public class ChatRoom {
// ...
}
SQLDelete: Delete 대신 실행할 SQL을 지정한다.
Where: 의미적으로 삭제되지 않은 레코드를 구분할 수 있게 where clause를 지정한다.
```
## Think About..  
현재 ChatRoom Entity에 Where를 적용하였는데, 만약 soft delete된 레코드를 retrieve하려면 Where를 쓰면 안된다.
대신
@FilterDef(name = "deletedAtFilter", parameters = @ParamDef(name = "deletedAt", type = "LocalDateTime"))
@Filter(name = "deletedAtFilter", condition = "deletedAt= :deletedAt")
와 같이 설정하여야 한다.
또한 서비스단에서 다음과 같이 retrieve method를 작성하고 사용한다.
```java
    public List<ChatRoom> findAll(LocalDateTime deletedAt){
        Session session = entityManager.unwrap(Session.class);
        Filter filter = session.enableFilter("deletedAtFilter");
        filter.setParameter("deletedAt", deletedAt);
        List<ChatRoom> chatRooms=  chatRoomRepository.findAll();
        session.disableFilter("deletedAtFilter");
        return chatRooms;
    }
```

또는,

Where, FilterDef, Filter를 모두 사용하지 않고 
repository interface에서 직접 메서드를 재정의할 수도 있다.

후자의 방법으로 다시 구현해야겠다
## Conclusion  
> 
