### PR TITLE
GM-172 Feign Client 설정 및 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.kafka:spring-kafka'
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/gaaji/chat/ChatApplication.java
+++ b/src/main/java/com/gaaji/chat/ChatApplication.java
@@ -3,11 +3,13 @@ package com.gaaji.chat;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableEurekaClient
+@EnableFeignClients
 public class ChatApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/gaaji/chat/adapter/feign/AuthFeignClient.java
+++ b/src/main/java/com/gaaji/chat/adapter/feign/AuthFeignClient.java
@@ -1,0 +1,12 @@
+package com.gaaji.chat.adapter.feign;
+
+import com.gaaji.chat.adapter.feign.dto.AuthFeignClientDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient("auth-service")
+public interface AuthFeignClient {
+    @GetMapping("/auth/{authId}")
+    AuthFeignClientDto findAuthById(@PathVariable("authId") String authId);
+}

--- a/src/main/java/com/gaaji/chat/adapter/feign/dto/AuthFeignClientDto.java
+++ b/src/main/java/com/gaaji/chat/adapter/feign/dto/AuthFeignClientDto.java
@@ -1,0 +1,11 @@
+package com.gaaji.chat.adapter.feign.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AuthFeignClientDto {
+    private String authId;
+    private String nickname;
+}

--- a/src/main/java/com/gaaji/chat/adapter/feign/dto/AuthFeignErrorResponse.java
+++ b/src/main/java/com/gaaji/chat/adapter/feign/dto/AuthFeignErrorResponse.java
@@ -1,0 +1,22 @@
+package com.gaaji.chat.adapter.feign.dto;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.FeignException;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import java.nio.charset.StandardCharsets;
+
+@Getter
+public class AuthFeignErrorResponse {
+    private HttpStatus httpStatus;
+    private String errorCode;
+    private String errorName;
+    private String errorMessage;
+
+    public static AuthFeignErrorResponse of (FeignException e) throws JsonProcessingException {
+        String body = StandardCharsets.UTF_8.decode(e.responseBody().orElseThrow(() -> e)).toString();
+        return new ObjectMapper().readValue(body, AuthFeignErrorResponse.class);
+    }
+}

--- a/src/main/java/com/gaaji/chat/controller/TestController.java
+++ b/src/main/java/com/gaaji/chat/controller/TestController.java
@@ -1,0 +1,21 @@
+package com.gaaji.chat.controller;
+
+import com.gaaji.chat.service.UserSearchUsingFeignService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TestController {
+    private final UserSearchUsingFeignService userSearchUsingFeignService;
+
+    @GetMapping("/user/{userId}/name")
+    @ResponseStatus(HttpStatus.OK)
+    public String getUserName(@PathVariable String userId) {
+        return userSearchUsingFeignService.searchById(userId).getName();
+    }
+}

--- a/src/main/java/com/gaaji/chat/domain/User.java
+++ b/src/main/java/com/gaaji/chat/domain/User.java
@@ -9,6 +9,8 @@ import lombok.NoArgsConstructor;
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Entity
 @Getter
@@ -20,21 +22,29 @@ public class User {
 
     private String name;
 
-    @OneToMany(mappedBy = "member")
+    @OneToMany(mappedBy = "member", cascade = CascadeType.PERSIST)
     private List<ChatRoomMember> chatRoomMembers = new ArrayList<>();
 
     @OneToMany(mappedBy = "owner")
     private List<Post> posts;
 
-    @OneToMany(cascade = CascadeType.PERSIST)
-    private List<ChatRoom> chatRooms;
-
     public User(String id) {
         this.id = id;
     }
 
+    public static User create(String id, String name) {
+        User user = new User();
+        user.id = id;
+        user.name = name;
+        return user;
+    }
+
     public void addUserRoom(ChatRoomMember chatRoomMember) {
         this.chatRoomMembers.add(chatRoomMember);
+    }
+
+    public List<ChatRoom> getChatRooms() {
+        return chatRoomMembers.stream().map(chatRoomMember -> chatRoomMember.getChatRoom()).collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/com/gaaji/chat/service/UserSearchUsingFeignService.java
+++ b/src/main/java/com/gaaji/chat/service/UserSearchUsingFeignService.java
@@ -1,0 +1,7 @@
+package com.gaaji.chat.service;
+
+import com.gaaji.chat.domain.User;
+
+public interface UserSearchUsingFeignService {
+    User searchById(String id) ;
+}

--- a/src/main/java/com/gaaji/chat/service/UserSearchUsingFeignServiceImpl.java
+++ b/src/main/java/com/gaaji/chat/service/UserSearchUsingFeignServiceImpl.java
@@ -1,0 +1,46 @@
+package com.gaaji.chat.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.gaaji.chat.adapter.feign.AuthFeignClient;
+import com.gaaji.chat.adapter.feign.dto.AuthFeignClientDto;
+import com.gaaji.chat.adapter.feign.dto.AuthFeignErrorResponse;
+import com.gaaji.chat.domain.User;
+import com.gaaji.chat.execption.InternalServerException;
+import com.gaaji.chat.execption.UserNotFoundException;
+import com.gaaji.chat.repository.UserRepository;
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class UserSearchUsingFeignServiceImpl implements UserSearchUsingFeignService {
+    private final AuthFeignClient authFeignClient;
+    private final UserRepository userRepository;
+
+    @Override
+    public User searchById(String id) {
+        return userRepository.findById(id).orElseGet(() -> {
+            AuthFeignClientDto authFeignClientDto = findAuthByIdUsingFeign(id);
+            return userRepository.save(User.create(authFeignClientDto.getAuthId(), authFeignClientDto.getNickname()));
+        });
+    }
+
+    private AuthFeignClientDto findAuthByIdUsingFeign(String id) {
+        try {
+            return authFeignClient.findAuthById(id);
+        } catch (FeignException e) {
+            try {
+                AuthFeignErrorResponse errorResponse = AuthFeignErrorResponse.of(e);
+                if(!errorResponse.getErrorName().equals("AUTH_ID_NOT_FOUND")) throw new InternalServerException();
+                throw new UserNotFoundException();
+            } catch (JsonProcessingException ex) {
+                throw new InternalServerException();
+            }
+        }
+    }
+}

--- a/src/test/java/com/gaaji/chat/service/GroupChatServiceImplTest.java
+++ b/src/test/java/com/gaaji/chat/service/GroupChatServiceImplTest.java
@@ -121,11 +121,12 @@ class GroupChatServiceImplTest {
         ObjectMapper objectMapper = new ObjectMapper();
 
         groupChatService.handleBanzzakCreated(objectMapper.writeValueAsString(BanzzakCreatedEventDto.create(newBanzzak)));
-        Banzzak banzzak = banzzakRepository.findById(newBanzzak.getId()).get();
-        ChatRoom chatRoom = banzzak.getChatRoom();
+        ChatRoom chatRoom = em.find(ChatRoom.class, newBanzzak.getChatRoom().getId());
+        Assertions.assertNotNull(chatRoom);
         groupChatService.handleBanzzakDeleted(objectMapper.writeValueAsString(BanzzakDeletedEventDto.create(newBanzzak.getId())));
-
-        Assertions.assertFalse(chatRoomRepository.findById(chatRoom.getId()).isPresent());
-        Assertions.assertFalse(banzzakRepository.findById(newBanzzak.getId()).isPresent());
+        chatRoom = em.find(ChatRoom.class, newBanzzak.getChatRoom().getId());
+        Assertions.assertNull(chatRoom);
+        Banzzak banzzak = em.find(Banzzak.class, newBanzzak.getId());
+        Assertions.assertNull(banzzak);
     }
 }


### PR DESCRIPTION
# GM-172 Feign Client 설정 및 구현
## Description
chat-api service에서 User는 Auth 서비스에 종속적으로 따라 존재한다.
Auth 서비스로부터 Auth 리소스를 가져오는 Feign Client를 정의한다.
User를 검색할 때 UserRepository에 존재하지 않으면 Auth Feign Client를 사용해 Auth Service로부터 가져온다. 그래도 없으면 NOT_FOUND다.

## PR Type
- [ ] Hotfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor (code, package, etc.)
- [ ] Build (gradle, spring, etc) 
- [ ] Documentation content changes (api docs, etc.)
- [ ] Infra (cloud, security, etc.)
- [ ] Other... Please describe :


## Issues
```java
@FeignClient("auth-service")
public interface AuthFeignClient {
    @GetMapping("/auth/{authId}")
    AuthFeignClientDto findAuthById(@PathVariable("authId") String authId);
}
```
```java
@Service
@RequiredArgsConstructor
@Transactional(readOnly = true)
@Slf4j
public class UserSearchUsingFeignServiceImpl implements UserSearchUsingFeignService {
    // ...
    @Override
    public User searchById(String id) {
        return userRepository.findById(id).orElseGet(() -> {
            AuthFeignClientDto authFeignClientDto = findAuthByIdUsingFeign(id);
            return userRepository.save(User.create(authFeignClientDto.getAuthId(), authFeignClientDto.getNickname()));
        });
    }

    private AuthFeignClientDto findAuthByIdUsingFeign(String id) {
        try {
            return authFeignClient.findAuthById(id);
        } catch (FeignException e) {
            try {
                AuthFeignErrorResponse errorResponse = AuthFeignErrorResponse.of(e);
                if(!errorResponse.getErrorName().equals("AUTH_ID_NOT_FOUND")) throw new InternalServerException();
                throw new UserNotFoundException();
            } catch (JsonProcessingException ex) {
                throw new InternalServerException();
            }
        }
    }
}
```

### Test
UserRepository에 찾는 User가 없는 경우 Fiegn Client를 통해 가져와야 하는데 현재 eureka, gateway가 연결되어있지 않아 테스트가 불가능하다.

*** 
## Think About..  
추후 시스템 통합 후 테스트 보강 필요

