### PR TITLE
GM-199 impl get chat-room to sync SMS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.kafka:spring-kafka-test'
+	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 }
 
 dependencyManagement {

--- a/src/main/java/com/gaaji/chat/controller/ChatRoomRetrieveToSyncWithStatusManagementServerController.java
+++ b/src/main/java/com/gaaji/chat/controller/ChatRoomRetrieveToSyncWithStatusManagementServerController.java
@@ -1,0 +1,22 @@
+package com.gaaji.chat.controller;
+
+import com.gaaji.chat.controller.dto.ChatRoomRetrieveToSyncWithStatusManagementServerResponseDto;
+import com.gaaji.chat.service.ChatRoomRetrieveToSyncWithStatusManagementServerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ChatRoomRetrieveToSyncWithStatusManagementServerController {
+    private final ChatRoomRetrieveToSyncWithStatusManagementServerService chatRoomRetrieveToSyncWithStatusManagementServerService;
+
+    @GetMapping("/chat-rooms/{chatRoomId}")
+    @ResponseStatus(HttpStatus.OK)
+    public ChatRoomRetrieveToSyncWithStatusManagementServerResponseDto chatRoom(@PathVariable String chatRoomId) {
+        return chatRoomRetrieveToSyncWithStatusManagementServerService.retrieveChatRoom(chatRoomId);
+    }
+}

--- a/src/main/java/com/gaaji/chat/controller/dto/ChatRoomRetrieveToSyncWithStatusManagementServerResponseDto.java
+++ b/src/main/java/com/gaaji/chat/controller/dto/ChatRoomRetrieveToSyncWithStatusManagementServerResponseDto.java
@@ -1,0 +1,20 @@
+package com.gaaji.chat.controller.dto;
+
+import com.gaaji.chat.domain.chatroom.ChatRoom;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class ChatRoomRetrieveToSyncWithStatusManagementServerResponseDto {
+    private String roomId;
+    private List<String> memberIds = new ArrayList<>();
+
+    public static ChatRoomRetrieveToSyncWithStatusManagementServerResponseDto of(ChatRoom chatRoom) {
+        ChatRoomRetrieveToSyncWithStatusManagementServerResponseDto dto = new ChatRoomRetrieveToSyncWithStatusManagementServerResponseDto();
+        dto.roomId = chatRoom.getId();
+        chatRoom.getMembers().forEach(user -> dto.getMemberIds().add(user.getId()));
+        return dto;
+    }
+}

--- a/src/main/java/com/gaaji/chat/service/ChatRoomRetrieveToSyncWithStatusManagementServerService.java
+++ b/src/main/java/com/gaaji/chat/service/ChatRoomRetrieveToSyncWithStatusManagementServerService.java
@@ -1,0 +1,8 @@
+package com.gaaji.chat.service;
+
+import com.gaaji.chat.controller.dto.ChatRoomRetrieveToSyncWithStatusManagementServerResponseDto;
+
+public interface ChatRoomRetrieveToSyncWithStatusManagementServerService {
+
+    ChatRoomRetrieveToSyncWithStatusManagementServerResponseDto retrieveChatRoom(String chatRoomId);
+}

--- a/src/main/java/com/gaaji/chat/service/ChatRoomRetrieveToSyncWithStatusManagementServerServiceImpl.java
+++ b/src/main/java/com/gaaji/chat/service/ChatRoomRetrieveToSyncWithStatusManagementServerServiceImpl.java
@@ -1,0 +1,20 @@
+package com.gaaji.chat.service;
+
+import com.gaaji.chat.controller.dto.ChatRoomRetrieveToSyncWithStatusManagementServerResponseDto;
+import com.gaaji.chat.execption.ChatRoomNotFoundException;
+import com.gaaji.chat.repository.ChatRoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatRoomRetrieveToSyncWithStatusManagementServerServiceImpl implements ChatRoomRetrieveToSyncWithStatusManagementServerService {
+    private final ChatRoomRepository chatRoomRepository;
+
+    @Override
+    public ChatRoomRetrieveToSyncWithStatusManagementServerResponseDto retrieveChatRoom(String chatRoomId) {
+        return ChatRoomRetrieveToSyncWithStatusManagementServerResponseDto.of(chatRoomRepository.findById(chatRoomId).orElseThrow(ChatRoomNotFoundException::new));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,3 +25,20 @@ spring:
       - classpath:eureka-config.yml
   application:
     name: chat-api
+---
+events:
+  post:
+    banzzak:
+      created: "post-banzzakCreated"
+      deleted: "post-banzzakDeleted"
+      user-joined: "post-banzzakUserJoined"
+      user-left: "post-banzzakUserLeft"
+  chat:
+    chat-room:
+      created: "chat-chatRoomCreated"
+      deleted: "chat-chatRoomDeleted"
+    member:
+      added: "chat-memberAdded"
+      left: "chat-memberLeft"
+
+

--- a/src/test/java/com/gaaji/chat/config/EventPropsTest.java
+++ b/src/test/java/com/gaaji/chat/config/EventPropsTest.java
@@ -1,0 +1,25 @@
+package com.gaaji.chat.config;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ContextConfiguration(initializers = ConfigDataApplicationContextInitializer.class)
+class EventPropsTest {
+
+    @Autowired
+    EventProps eventProps;
+
+    @Test
+    public void test() {
+        Assertions.assertNotNull(eventProps);
+        assertEquals("post-banzzakCreated", eventProps.getPost().getBanzzak().getCreated());
+    }
+
+}


### PR DESCRIPTION

GM-199 impl get chat-room to sync SMS
SMS: status management server

## Description
Status Management Server는 chat-api와의 데이터 동기화는 이용해 이 엔드포인트를 사용한다.

## PR Type
- [ ] Hotfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor (code, package, etc.)
- [ ] Build (gradle, spring, etc) 
- [ ] Documentation content changes (api docs, etc.)
- [ ] Infra (cloud, security, etc.)
- [ ] Other... Please describe :


## Issues
```java
//controller
    @GetMapping("/chat-rooms/{chatRoomId}")
    @ResponseStatus(HttpStatus.OK)
    public ChatRoomRetrieveToSyncWithStatusManagementServerResponseDto chatRoom(@PathVariable String chatRoomId) {
        return chatRoomRetrieveToSyncWithStatusManagementServerService.retrieveChatRoom(chatRoomId);
    }
```
```java
//response dto
@Getter
public class ChatRoomRetrieveToSyncWithStatusManagementServerResponseDto {
    private String roomId;
    private List<String> memberIds = new ArrayList<>();
}
```
exception: id에 해당하는 리소스가 없는 경우 ChatRoomNotFoundException
```java
    CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "C-0005", "CHAT_ROOM_NOT_FOUND"),
```
